### PR TITLE
Update hero buttons to link to HTML pages

### DIFF
--- a/pages/home.js
+++ b/pages/home.js
@@ -11,8 +11,8 @@ export default function Home() {
 
     <section class="hero-cta">
       <div class="hero-buttons">
-        <a href="/signup" data-link class="btn btn-primary">Sign Up</a>
-        <a href="/login" data-link class="btn btn-secondary">Log In</a>
+        <a href="/pages/signup.html" class="btn btn-primary">Sign Up</a>
+        <a href="/pages/login.html" class="btn btn-secondary">Log In</a>
       </div>
     </section>
   `;


### PR DESCRIPTION
Changed the 'Sign Up' and 'Log In' buttons to point directly to /pages/signup.html and /pages/login.html


This pull request for this ticket: User Story 3: Implement a Pixel-Perfect Signup Page
[#17] . 