### PR TITLE
Add manage/results UI, modals, and JS enhancements

### DIFF
--- a/css/my-results.css
+++ b/css/my-results.css
@@ -1,241 +1,629 @@
 * {
-    box-sizing: border-box;
-    line-height: var(--line-height);
+  box-sizing: border-box;
+  line-height: var(--line-height);
 }
 
 body {
-    text-align: center;
-    background-color: var(--color-neutral-gray);
-    color: var(--color-neutral-dark-gray);
+  text-align: center;
+  background-color: var(--color-neutral-gray);
+  color: var(--color-neutral-dark-gray);
+}
+
+main {
+  margin: var(--padding-24px) 0;
 }
 
 p {
-    margin: 2.5em auto;
-    font-family: var(--secondary-font);
-    font-weight: 400;
+  margin: var(--padding-24px) auto;
+  font-family: var(--secondary-font);
+  font-weight: 400;
+  font-size: var(--paragraph);
 }
 
 .results-icon img {
-    width: 35px;
-    margin: 0 auto;
+  width: 35px;
+  margin: 0 auto;
 }
 
 .search-wrapper {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    max-width: 250px;
-    margin: 0 auto;
-    border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  max-width: 250px;
+  margin: 0 auto;
+  border-radius: 6px;
 }
 
 input,
 .search-button {
-    border: none;
-    background: #ffffff;
+  border: none;
+  background: #ffffff;
 }
 
 input {
-    font-family: var(--secondary-font), sans-serif;
-    flex: 1;
-    padding: 8px;
-    color: var(--color-neutral-dark-gray);
-    border-style: solid;
-    border-color: var(--color-neutral-medium-gray);
-    border-width: 1px 0 1px 1px;
-    border-radius: 6px 0 0 6px;
+  font-family: var(--secondary-font), sans-serif;
+  flex: 1;
+  padding: var(--padding-8px);
+  color: var(--color-neutral-dark-gray);
+  border-style: solid;
+  border-color: var(--color-neutral-medium-gray);
+  border-width: 1px 0 1px 1px;
+  border-radius: 6px 0 0 6px;
 }
 
 .search-button {
-    border-radius: 0;
-    display: flex;
-    align-self: stretch;
-    border: 1px solid var(--primary-color);
-    border-radius: 0 6px 6px 0;
+  border-radius: 0;
+  display: flex;
+  align-self: stretch;
+  border: 1px solid var(--primary-color);
+  border-radius: 0 6px 6px 0;
 }
 
 .search-button:hover {
-    background-color: rgba(0, 0, 0, 0.03);
+  background-color: var(--color-neutral-gray);
 }
 
 .search-button:active {
-    background-color: rgba(0, 0, 0, 0.08);
+  background-color: var(--color-neutral-gray);
 }
 
 .search-button img {
-    width: 20px;
-    padding: 2px;
-    align-self: center;
+  width: 20px;
+  padding: 2px;
+  align-self: center;
+}
+
+/* Add result button */
+.add-result-btn {
+  display: none;
+  font-family: var(--primary-font), sans-serif;
+  font-weight: 600;
+  font-size: var(--paragraph);
+  color: #ffffff;
+  background-color: var(--primary-color);
+  text-decoration: none;
+  border: none;
+  border-radius: 6px;
+  padding: 10px 20px;
+  cursor: pointer;
+}
+
+.add-result-btn:hover {
+  background-color: #388e3c;
+}
+
+body.manage-results .add-result-btn {
+  display: inline-block;
 }
 
 .table-container {
-    width: 100%;
-    max-width: 900px;
-    margin: 3em auto;
-    padding: 0 1.5em;
-    overflow-x: auto;
-    text-align: left;
+  display: grid;
+  justify-items: end;
+  width: 100%;
+  max-width: 900px;
+  margin: var(--padding-48px) auto;
+  padding: 0 var(--padding-24px);
+  overflow-x: auto;
+  text-align: left;
 }
 
 table {
-    font-family: var(--secondary-font), sans-serif;
-    width: 100%;
-    table-layout: fixed;
-    border-collapse: collapse;
+  font-family: var(--secondary-font), sans-serif;
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
 }
 
 th {
-    font-family: "Poppins", sans-serif;
-    font-weight: 700;
-    color: var(--primary-color);
-    height: 68px;
-    background-color: #ffffff;
+  font-family: "Poppins", sans-serif;
+  font-weight: 700;
+  color: var(--primary-color);
+  height: 68px;
+  background-color: #ffffff;
+  font-size: var(--small-txt);
 }
 
 th,
 td {
-    cursor: pointer;
+  cursor: pointer;
+  padding: 0 var(--padding-16px);
 }
 
 td {
-    height: 70px;
-    font-size: clamp(14px, 2vw, 16px);
+  height: 70px;
+  font-size: var(--paragraph);
 }
 
 tbody tr:nth-child(odd) {
-    background-color: #f9f9f9;
+  background-color: #f9f9f9;
 }
 
 tbody tr:nth-child(even) {
-    background-color: #ffffff;
+  background-color: #ffffff;
 }
 
 tbody tr:hover td {
-    background-color: #f0f0f0;
+  background-color: #f0f0f0;
+}
+
+/* Edit and Delete actions */
+.col-actions {
+  display: none;
+  padding-right: var(--padding-24px);
+}
+
+body.manage-results .col-actions {
+  display: table-cell;
+}
+
+.row-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--padding-8px);
+  align-items: center;
+}
+
+.edit-link {
+  color: var(--primary-color);
+  font-family: var(--secondary-font), sans-serif;
+  font-size: var(--paragraph);
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.edit-link:hover {
+  text-decoration: underline;
+}
+
+.delete-btn {
+  background-color: var(--accent-color);
+  color: #ffffff;
+  font-family: var(--primary-font), sans-serif;
+  font-weight: 600;
+  border: none;
+  padding: var(--padding-8px) var(--padding-16px);
+  border-radius: 6px;
+  letter-spacing: var(--letter-spacing);
+  cursor: pointer;
+}
+
+.delete-btn:hover {
+  background-color: #e64a19;
 }
 
 .row-info,
 .col-info {
-    display: none;
+  display: none;
 }
 
 .col-year {
-    padding-left: 1.5em;
+  padding-left: var(--padding-24px);
 }
 
 .pagination {
-    display: flex;
-    justify-content: center;
-    gap: 1em;
-    margin-bottom: 3em;
+  display: flex;
+  justify-content: center;
+  gap: var(--padding-16px);
+  margin-bottom: var(--padding-48px);
 }
 
 .page-btn {
-    width: 40px;
-    height: 40px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background-color: #ffffff;
-    color: var(--color-neutral-medium-gray);
-    border: 1px solid #d9d9d9;
-    border-radius: 6px;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #ffffff;
+  color: var(--color-neutral-medium-gray);
+  border: 1px solid #d9d9d9;
+  border-radius: 6px;
 }
 
 .page-btn.active {
-    color: var(--primary-color);
-    border: 2px solid var(--primary-color);
-    font-weight: 600;
+  color: var(--primary-color);
+  border: 2px solid var(--primary-color);
+  font-weight: 600;
 }
 
 .page-btn img {
-    width: 18px;
-    height: 18px;
-    object-fit: contain;
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
 }
 
 .single-arrow img {
-    height: 16px;
+  height: 16px;
 }
 
 .back-link {
-    display: inline-block;
-    font-family: var(--primary-font), sans-serif;
-    font-weight: 600;
-    color: var(--secondary-color);
-    text-decoration: none;
-    border: 2px solid var(--secondary-color);
-    border-radius: 6px;
-    padding: 8px 16px;
+  display: inline-block;
+  font-family: var(--primary-font), sans-serif;
+  font-weight: 600;
+  color: var(--secondary-color);
+  text-decoration: none;
+  border: 2px solid var(--secondary-color);
+  border-radius: 6px;
+  padding: 8px 16px;
 }
 
 .back-link:hover {
-    background-color: #bbdefb;
+  background-color: #bbdefb;
+}
+
+/* Modal Styles */
+.modal[aria-hidden="true"] {
+  display: none;
+}
+
+.modal[aria-hidden="false"] {
+  display: grid;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  place-items: center;
+}
+
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.55);
+}
+
+.modal-dialog {
+  position: relative;
+  width: min(500px, 95%);
+  background: #fff;
+  border-radius: 8px;
+  padding: var(--padding-24px);
+}
+
+.modal-dialog-outline {
+  border: 2px solid var(--secondary-color);
+}
+
+.modal-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  color: var(--secondary-color);
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.modal-close:hover {
+  color: var(--secondary-color);
+}
+
+.modal-content {
+  text-align: left;
+}
+
+.modal-title {
+  font-family: var(--primary-font), sans-serif;
+  font-size: var(--heading-3);
+  font-weight: 700;
+  color: var(--color-neutral-dark-gray);
+  margin-bottom: 16px;
+}
+
+.modal-text {
+  font-family: var(--secondary-font), sans-serif;
+  font-size: var(--paragraph);
+  margin: 0 0 24px 0;
+}
+
+/* Edit Modal Form */
+.edit-form {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-group label {
+  font-family: var(--primary-font), sans-serif;
+  font-weight: 600;
+  font-size: var(--small-txt);
+  color: var(--primary-color);
+}
+
+.form-group input {
+  font-family: var(--secondary-font), sans-serif;
+  font-size: var(--paragraph);
+  padding: 8px 12px;
+  border: 1px solid #cccccc;
+  border-radius: 6px;
+  color: var(--color-neutral-dark-gray);
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: var(--primary-color);
+}
+
+.form-group input[readonly] {
+  background-color: var(--color-neutral-gray);
+  cursor: default;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 16px;
+  margin-top: 24px;
+  grid-column: 1 / -1;
+}
+
+.modal-actions-split {
+  justify-content: space-between;
+}
+
+.update-btn {
+  background-color: var(--primary-color);
+  color: #ffffff;
+  font-family: var(--primary-font), sans-serif;
+  font-weight: 600;
+  border: none;
+  padding: 10px 24px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.update-btn:hover {
+  background-color: #388e3c;
+}
+
+.cancel-btn {
+  color: var(--secondary-color);
+  background: transparent;
+  font-family: var(--primary-font), sans-serif;
+  font-weight: 600;
+  border: 2px solid var(--secondary-color);
+  padding: 10px 24px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.cancel-btn:hover {
+  background-color: #bbdefb;
+}
+
+/* Delete Modal */
+.delete-btn-modal {
+  background-color: var(--accent-color);
+  border: 2px solid var(--accent-color);
+  color: #ffffff;
+  font-family: var(--primary-font), sans-serif;
+  font-weight: 600;
+  padding: 10px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.delete-btn-modal:hover {
+  background-color: #e64a19;
+  border-color: #e64a19;
+}
+
+/* Page Ellipsis for Pagination */
+.page-ellipsis {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  color: var(--color-neutral-medium-gray);
+  border: 1px solid #d9d9d9;
+  border-radius: 6px;
+  background: #fff;
 }
 
 @media (max-width: 600px) {
+  main {
+    margin: var(--padding-16px) 0;
+    padding: 0 var(--padding-16px);
+  }
 
-    .results-icon {
-        display: block;
-    }
+  h1 {
+    font-size: var(--heading-2);
+    margin-bottom: var(--padding-8px);
+  }
 
-    p {
-        margin: 1em 0 1.5em 0;
-    }
+  .results-icon {
+    display: block;
+  }
 
-    .table-container {
-        margin: 2.5em 0;
-        border-radius: 8px;
-        text-align: left;
-    }
+  p {
+    margin: var(--padding-8px) 0 var(--padding-16px) 0;
+    font-size: var(--small-txt);
+  }
 
-    table {
-        table-layout: auto;
-    }
+  .search-wrapper {
+    max-width: 100%;
+    margin: 0 auto var(--padding-16px) auto;
+  }
 
-    th,
-    td {
-        height: 56px;
-    }
+  .table-container {
+    margin: var(--padding-16px) 0;
+    padding: 0;
+    border-radius: 8px;
+    text-align: left;
+  }
 
-    .col-hidden,
-    .col-year,
-    .col-term,
-    .col-result {
-        display: none;
-    }
+  /* Add result button mobile */
+  body.manage-results .add-result-btn {
+    display: inline-block;
+    margin-bottom: var(--padding-16px);
+    font-size: var(--small-txt);
+    padding: var(--padding-8px) var(--padding-16px);
+  }
 
-    .col-subject {
-        padding-left: .8em;
-    }
+  table {
+    table-layout: auto;
+    width: 100%;
+  }
 
-    .col-info {
-        display: block;
-    }
+  th {
+    height: 48px;
+    font-size: var(--small-txt);
+    padding: 0 var(--padding-8px);
+  }
 
-    .pagination {
-        gap: .5em;
-    }
+  td {
+    height: 52px;
+    font-size: var(--small-txt);
+    padding: 0 var(--padding-8px);
+  }
 
-    .row-info {
-        display: flex;
-        align-items: center;
-    }
+  th,
+  td {
+    padding: 0 var(--padding-8px);
+  }
 
-    .info-btn {
-        background: transparent;
-        cursor: pointer;
-        display: flex;
-        border: none;
-    }
+  /* Hide columns on mobile */
+  .col-hidden,
+  .col-year,
+  .col-term,
+  .col-result {
+    display: none !important;
+  }
 
-    .info-btn img {
-        width: 22px;
-        object-fit: contain;
-    }
+  /* Hide desktop action column on mobile */
+  .col-actions {
+    display: none !important;
+  }
 
-    .page-btn {
-        width: 35px;
-        height: 35px;
-    }
+  .col-subject {
+    padding-left: var(--padding-8px);
+  }
+
+  /* Show info column on mobile */
+  .col-info {
+    display: table-cell;
+    width: 50px;
+    text-align: center;
+  }
+
+  .row-info {
+    display: table-cell;
+    text-align: center;
+    vertical-align: middle;
+  }
+
+  .info-btn {
+    background: transparent;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    padding: var(--padding-8px);
+  }
+
+  .info-btn img {
+    width: 20px;
+    height: 20px;
+    object-fit: contain;
+  }
+
+  /* Pagination mobile */
+  .pagination {
+    gap: var(--padding-8px);
+    margin-bottom: var(--padding-24px);
+    flex-wrap: wrap;
+  }
+
+  .page-btn {
+    width: 32px;
+    height: 32px;
+    font-size: var(--small-txt);
+  }
+
+  .page-btn img {
+    width: 14px;
+    height: 14px;
+  }
+
+  .page-ellipsis {
+    width: 32px;
+    height: 32px;
+    font-size: var(--small-txt);
+  }
+
+  .back-link {
+    font-size: var(--small-txt);
+    padding: var(--padding-8px) var(--padding-16px);
+    margin-bottom: var(--padding-24px);
+  }
+
+  /* Modal responsive */
+  .modal-dialog {
+    width: calc(100% - 32px);
+    max-width: 380px;
+    margin: var(--padding-16px);
+    padding: var(--padding-16px);
+  }
+
+  .modal-close {
+    top: 12px;
+    right: 12px;
+    font-size: 20px;
+  }
+
+  .modal-title {
+    font-size: 18px;
+    margin-bottom: var(--padding-16px);
+    padding-right: 24px;
+  }
+
+  .modal-text {
+    font-size: var(--small-txt);
+    margin-bottom: var(--padding-16px);
+  }
+
+  .edit-form {
+    grid-template-columns: 1fr 1fr;
+    gap: var(--padding-8px);
+  }
+
+  .form-group {
+    gap: 4px;
+  }
+
+  .form-group label {
+    font-size: 12px;
+  }
+
+  .form-group input {
+    font-size: var(--small-txt);
+    padding: var(--padding-8px);
+  }
+
+  .modal-actions {
+    margin-top: var(--padding-16px);
+    gap: var(--padding-8px);
+  }
+
+  .modal-actions-split {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .update-btn,
+  .cancel-btn,
+  .delete-btn-modal {
+    padding: var(--padding-8px) var(--padding-16px);
+    font-size: var(--small-txt);
+  }
 }

--- a/css/select-user.css
+++ b/css/select-user.css
@@ -1,381 +1,548 @@
 * {
-    box-sizing: border-box;
-    line-height: var(--line-height);
+  box-sizing: border-box;
+  line-height: var(--line-height);
 }
 
 body {
-    text-align: center;
-    background-color: var(--color-neutral-gray);
-    color: var(--color-neutral-dark-gray);
+  text-align: center;
+  background-color: var(--color-neutral-gray);
+  color: var(--color-neutral-dark-gray);
 }
 
 main {
-    margin: 2em 0;
+  margin: var(--padding-24px) 0;
 }
 
 p {
-    margin: 2.5em;
-    font-family: var(--secondary-font);
-    font-weight: 400;
+  margin: var(--padding-24px) auto;
+  font-family: var(--secondary-font);
+  font-weight: 400;
+  font-size: var(--paragraph);
 }
 
 a {
-    text-decoration: none;
+  text-decoration: none;
+}
+
+.results-icon img {
+  width: 35px;
+  margin: 0 auto;
 }
 
 .search-wrapper {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    max-width: 250px;
-    margin: 0 auto;
-    border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  max-width: 250px;
+  margin: 0 auto;
+  border-radius: 6px;
 }
 
 input,
 .search-button {
-    border: none;
-    background: #ffffff;
+  border: none;
+  background: #ffffff;
 }
 
 input {
-    font-family: var(--secondary-font), sans-serif;
-    flex: 1;
-    padding: 8px;
-    color: var(--color-neutral-dark-gray);
-    border-style: solid;
-    border-color: var(--color-neutral-medium-gray);
-    border-width: 1px 0 1px 1px;
-    border-radius: 6px 0 0 6px;
+  font-family: var(--secondary-font), sans-serif;
+  flex: 1;
+  padding: var(--padding-8px);
+  color: var(--color-neutral-dark-gray);
+  border-style: solid;
+  border-color: var(--color-neutral-medium-gray);
+  border-width: 1px 0 1px 1px;
+  border-radius: 6px 0 0 6px;
 }
 
 .search-button {
-    border-radius: 0;
-    display: flex;
-    align-self: stretch;
-    border: 1px solid var(--primary-color);
-    border-radius: 0 6px 6px 0;
+  border-radius: 0;
+  display: flex;
+  align-self: stretch;
+  border: 1px solid var(--primary-color);
+  border-radius: 0 6px 6px 0;
 }
 
 .search-button:hover {
-    background-color: rgba(0, 0, 0, 0.03);
+  background-color: var(--color-neutral-gray);
 }
 
 .search-button:active {
-    background-color: rgba(0, 0, 0, 0.08);
+  background-color: var(--color-neutral-gray);
 }
 
 .search-button img {
-    width: 20px;
-    padding: 2px;
-    align-self: center;
+  width: 20px;
+  padding: 2px;
+  align-self: center;
 }
 
 .add-user-btn {
-    display: inline-block;
-    margin-bottom: 1.5em;
-    font-family: var(--primary-font), sans-serif;
-    font-weight: 600;
-    color: #ffffff;
-    background-color: var(--primary-color);
-    text-decoration: none;
-    border-radius: 6px;
-    padding: 8px 16px;
+  display: inline-block;
+  margin-bottom: var(--padding-24px);
+  font-family: var(--primary-font), sans-serif;
+  font-weight: 600;
+  font-size: var(--paragraph);
+  color: #ffffff;
+  background-color: var(--primary-color);
+  text-decoration: none;
+  border-radius: 6px;
+  padding: 10px 20px;
 }
 
 .add-user-btn:hover {
-    background-color: #388E3C;
+  background-color: #388e3c;
 }
 
 /*   Table  */
 
 .table-container {
-    display: grid;
-    justify-items: end;
-    width: 100%;
-    max-width: 900px;
-    margin: 3em auto;
-    padding: 0 1.5em;
-    overflow-x: auto;
-    text-align: left;
+  display: grid;
+  justify-items: end;
+  width: 100%;
+  max-width: 900px;
+  margin: var(--padding-48px) auto;
+  padding: 0 var(--padding-24px);
+  overflow-x: auto;
+  text-align: left;
 }
 
 table {
-    font-family: var(--secondary-font), sans-serif;
-    width: 100%;
-    table-layout: auto;
-    border-collapse: collapse;
+  font-family: var(--secondary-font), sans-serif;
+  width: 100%;
+  table-layout: auto;
+  border-collapse: collapse;
 }
 
 th {
-    font-family: "Poppins", sans-serif;
-    font-weight: 700;
-    color: var(--primary-color);
-    height: 68px;
-    background-color: #ffffff;
+  font-family: "Poppins", sans-serif;
+  font-weight: 700;
+  color: var(--primary-color);
+  height: 68px;
+  background-color: #ffffff;
+  font-size: var(--small-txt);
 }
 
 th,
 td {
-    cursor: pointer;
-    padding-right: 1em;
+  cursor: pointer;
+  padding: 0 var(--padding-16px);
 }
 
 .label-mobile {
-    display: none;
+  display: none;
 }
 
 td {
-    height: 70px;
-    font-size: clamp(14px, 2vw, 16px);
+  height: 70px;
+  font-size: var(--paragraph);
 }
 
 tbody tr:nth-child(odd) {
-    background-color: #f9f9f9;
+  background-color: #f9f9f9;
 }
 
 tbody tr:nth-child(even) {
-    background-color: #ffffff;
+  background-color: #ffffff;
 }
 
 tbody tr:hover td {
-    background-color: #f0f0f0;
+  background-color: #f0f0f0;
+}
+
+/* Results mode - make rows clickable */
+body.results-mode tbody tr {
+  cursor: pointer;
+}
+
+/* Hide columns with col-hidden class */
+.col-hidden {
+  display: none;
 }
 
 .col-id {
-    padding-left: 1.5em;
+  padding-left: var(--padding-24px);
+}
+
+/* Hide certain columns by default in results mode */
+body.results-mode .col-role,
+body.results-mode .col-dob {
+  display: none;
+}
+
+/* Show first name and year columns in results mode */
+body.results-mode .col-first-name,
+body.results-mode .col-year {
+  display: table-cell;
 }
 
 .edit-link {
-    color: var(--primary-color);
-    font-size: 16px;
+  color: var(--primary-color);
+  font-family: var(--secondary-font), sans-serif;
+  font-size: var(--paragraph);
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
 }
 
 .edit-link:hover {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .col-actions {
-    padding-right: 1.5em;
+  padding-right: var(--padding-24px);
 }
 
 .row-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5em;
-    align-items: center;
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--padding-8px);
+  align-items: center;
 }
 
 .delete-btn {
-    background-color: var(--accent-color);
-    color: #ffffff;
-    border: none;
-    padding: 8px 16px;
-    border-radius: 6px;
-    letter-spacing: var(--letter-spacing);
+  background-color: var(--accent-color);
+  color: #ffffff;
+  font-family: var(--primary-font), sans-serif;
+  font-weight: 600;
+  border: none;
+  padding: var(--padding-8px) var(--padding-16px);
+  border-radius: 6px;
+  letter-spacing: var(--letter-spacing);
+  cursor: pointer;
 }
 
 .delete-btn:hover {
-    background-color: #E64A19;
-    cursor: pointer;
+  background-color: #e64a19;
+}
+
+/* Info button column */
+.row-info,
+.col-info {
+  display: none;
+}
+
+.info-btn {
+  background: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  padding: var(--padding-8px);
+}
+
+.info-btn img {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
 }
 
 /* pagination */
 
 .pagination {
-    display: flex;
-    justify-content: center;
-    gap: 1em;
-    margin-bottom: 3em;
+  display: flex;
+  justify-content: center;
+  gap: var(--padding-16px);
+  margin-bottom: var(--padding-48px);
 }
 
 .page-btn {
-    width: 40px;
-    height: 40px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background-color: #ffffff;
-    color: var(--color-neutral-medium-gray);
-    border: 1px solid #d9d9d9;
-    border-radius: 6px;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #ffffff;
+  color: var(--color-neutral-medium-gray);
+  border: 1px solid #d9d9d9;
+  border-radius: 6px;
 }
 
 .page-btn.active {
-    color: var(--primary-color);
-    border: 2px solid var(--primary-color);
-    font-weight: 600;
+  color: var(--primary-color);
+  border: 2px solid var(--primary-color);
+  font-weight: 600;
 }
 
 .page-btn img {
-    width: 18px;
-    height: 18px;
-    object-fit: contain;
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
 }
 
 .single-arrow img {
-    height: 16px;
+  height: 16px;
 }
 
 .page-ellipsis {
-    width: 42px;
-    height: 42px;
-    display: grid;
-    place-items: center;
-    color: #777;
-    border: 1px solid #eee;
-    border-radius: 8px;
-    background: #fff;
-  }
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  color: #777;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  background: #fff;
+}
 
 .back-link {
-    display: inline-block;
-    font-family: var(--primary-font), sans-serif;
-    font-weight: 600;
-    color: var(--secondary-color);
-    text-decoration: none;
-    border: 2px solid var(--secondary-color);
-    border-radius: 6px;
-    padding: 8px 16px;
+  display: inline-block;
+  font-family: var(--primary-font), sans-serif;
+  font-weight: 600;
+  color: var(--secondary-color);
+  text-decoration: none;
+  border: 2px solid var(--secondary-color);
+  border-radius: 6px;
+  padding: 8px 16px;
 }
 
 .back-link:hover {
-    background-color: #bbdefb;
+  background-color: #bbdefb;
 }
 
 /* modal */
 
-.modal[aria-hidden="true"] { 
-    display: none; 
+.modal[aria-hidden="true"] {
+  display: none;
 }
 
-.modal[aria-hidden="false"] { 
-    display: grid; 
+.modal[aria-hidden="false"] {
+  display: grid;
 }
 
 .modal {
-    position: fixed;
-    inset: 0;
-    z-index: 9999;
-    place-items: center;
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  place-items: center;
 }
 
 .modal-backdrop {
-    position: absolute;
-    inset: 0;
-    background-color: rgba(0, 0, 0, 0.55);
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.55);
 }
 
 .modal-dialog {
-    position: relative;
-    width: min(450px, 100%);
-    background: #fff;
-    border-radius: 8px;
-    padding: 1.5em;
+  position: relative;
+  width: min(450px, 100%);
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5em;
 }
 
 .modal-close {
-    position: absolute;
-    top: 25px;
-    right: 25px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    padding: 0;
+  position: absolute;
+  top: 25px;
+  right: 25px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
 }
 
 .modal-close img {
-    width: 17px;
-    height: 17px;
-    display: block;
+  width: 17px;
+  height: 17px;
+  display: block;
 }
 
 .modal-close:hover img {
-    content: url("../public/icons/x-close(1).jpg");
+  content: url("../public/icons/x-close(1).jpg");
 }
 
 .modal-content {
-    text-align: left;
+  text-align: left;
 }
 
 .modal-text {
-    margin: 0 0 1.5em 0;
+  margin: 0 0 1.5em 0;
 }
 
 .delete-btn-modal {
-    background-color: var(--accent-color);
-    border: 2px solid var(--accent-color);
-    color: #ffffff;
+  background-color: var(--accent-color);
+  border: 2px solid var(--accent-color);
+  color: #ffffff;
 }
 
 .delete-btn-modal:hover {
-    background-color: #E64A19;
-    border-color: #E64A19;
-    cursor: pointer;
+  background-color: #e64a19;
+  border-color: #e64a19;
+  cursor: pointer;
 }
 
 .modal-actions {
-    display: flex;
-    justify-content: space-between;
+  display: flex;
+  justify-content: space-between;
 }
 
 .cancel-btn {
-    color: var(--secondary-color);
-    border: 2px solid var(--secondary-color);
-    background: transparent;
+  color: var(--secondary-color);
+  border: 2px solid var(--secondary-color);
+  background: transparent;
 }
 
 .cancel-btn:hover {
-    background-color: #bbdefb;
-    cursor: pointer;
+  background-color: #bbdefb;
+  cursor: pointer;
 }
 
 .delete-btn-modal,
 .cancel-btn {
-    border-radius: 6px;
-    padding: 8px 16px;
-    letter-spacing: var(--letter-spacing);
+  border-radius: 6px;
+  padding: 8px 16px;
+  letter-spacing: var(--letter-spacing);
 }
 
 @media (max-width: 600px) {
+  main {
+    margin: var(--padding-16px) 0;
+    padding: 0 var(--padding-16px);
+  }
 
-    .add-user-btn {
-        display: none;
-    }
+  h1 {
+    font-size: var(--heading-2);
+    margin-bottom: var(--padding-8px);
+  }
 
-    .label-desktop {
-        display: none;
-    }
+  /* Show results icon on mobile in results mode */
+  body.results-mode .results-icon {
+    display: block;
+  }
 
-    .label-mobile {
-        display: block;
-    }
+  p {
+    margin: var(--padding-8px) 0 var(--padding-16px) 0;
+    font-size: var(--small-txt);
+  }
 
-    th,
-    td {
-        height: 60px;
-    }
+  .add-user-btn {
+    display: none;
+  }
 
-    .col-hidden {
-        display: none;
-    }
+  .search-wrapper {
+    max-width: 100%;
+    margin-bottom: var(--padding-16px);
+  }
 
-    .pagination {
-        gap: .5em;
-    }
+  .table-container {
+    margin: var(--padding-16px) 0;
+    padding: 0;
+  }
 
-    .page-btn img {
-        width: 13px;
-        height: 13px;
-    }
+  .label-desktop {
+    display: none;
+  }
 
-    .page-ellipsis,
-    .page-btn {
-        width: 30px;
-        height: 30px;
-    }
+  .label-mobile {
+    display: block;
+  }
 
-    .modal-dialog {
-        width: min(380px, 100%);
-    }
+  table {
+    width: 100%;
+    table-layout: auto;
+  }
+
+  th {
+    height: 48px;
+    font-size: var(--small-txt);
+    padding: 0 var(--padding-8px);
+  }
+
+  td {
+    height: 52px;
+    font-size: var(--small-txt);
+    padding: 0 var(--padding-8px);
+  }
+
+  th,
+  td {
+    padding: 0 var(--padding-8px);
+  }
+
+  .col-hidden,
+  .col-first-name,
+  .col-dob {
+    display: none;
+  }
+
+  /* Hide year and role columns on mobile in results mode */
+  body.results-mode .col-year,
+  body.results-mode .col-role {
+    display: none !important;
+  }
+
+  .col-id {
+    padding-left: var(--padding-8px);
+  }
+
+  /* Hide action column on mobile */
+  .col-actions {
+    display: none !important;
+  }
+
+  /* Show info column on mobile for results mode */
+  body.results-mode .col-info {
+    display: table-cell;
+    width: 50px;
+    text-align: center;
+  }
+
+  body.results-mode .row-info {
+    display: table-cell;
+    text-align: center;
+    vertical-align: middle;
+  }
+
+  .pagination {
+    gap: var(--padding-8px);
+    margin-bottom: var(--padding-24px);
+    flex-wrap: wrap;
+  }
+
+  .page-btn {
+    width: 32px;
+    height: 32px;
+    font-size: var(--small-txt);
+  }
+
+  .page-btn img {
+    width: 14px;
+    height: 14px;
+  }
+
+  .page-ellipsis {
+    width: 32px;
+    height: 32px;
+  }
+
+  .back-link {
+    font-size: var(--small-txt);
+    padding: var(--padding-8px) var(--padding-16px);
+  }
+
+  .modal-dialog {
+    width: calc(100% - 32px);
+    max-width: 380px;
+    margin: var(--padding-16px);
+    padding: var(--padding-16px);
+  }
+
+  .modal-title {
+    font-size: 18px;
+  }
+
+  .modal-text {
+    font-size: var(--small-txt);
+  }
+
+  .modal-actions {
+    flex-direction: row;
+  }
+
+  .delete-btn-modal,
+  .cancel-btn {
+    font-size: var(--small-txt);
+    padding: var(--padding-8px) var(--padding-16px);
+  }
 }

--- a/pages/admin-dashboard.html
+++ b/pages/admin-dashboard.html
@@ -39,9 +39,9 @@
         <img src="../public/icons/add-school.png" alt="Add teachers" class="dashboard-icon" />
         <p>Add School</p>
       </a>
-      <a href="#">
-        <img src="../public/icons/user-circle.png" alt="View profile" class="dashboard-icon" />
-        <p>See profile</p>
+      <a href="select-user.html?mode=results&role=student">
+        <img src="../public/icons/add-results.png" alt="View results" class="dashboard-icon" />
+        <p>View results</p>
       </a>
       <a href="#">
         <img src="../public/icons/logout.png" alt="Log out" class="dashboard-icon" />

--- a/pages/my-results.html
+++ b/pages/my-results.html
@@ -29,6 +29,7 @@
         </div>
       </div>
       <div class="table-container">
+        <a href="add-results.html" class="add-result-btn" id="add-result-btn">Add result</a>
         <table>
           <thead>
             <tr>
@@ -38,6 +39,7 @@
               <th>Exam</th>
               <th class="col-hidden">Result</th>
               <th>Grade</th>
+              <th class="col-actions col-hidden" id="actions-header">Action</th>
               <th class="col-info"></th>
             </tr>
           </thead>
@@ -45,7 +47,69 @@
         </table>
       </div>
       <div id="pagination" class="pagination"></div>
-      <a href="#" class="back-link">Back to dashboard</a>
+      <a href="#" class="back-link" id="back-link">Back to dashboard</a>
+
+      <div class="modal" id="edit-modal" aria-hidden="true">
+        <div class="modal-backdrop" data-close></div>
+        <div class="modal-dialog" aria-modal="true" aria-labelledby="edit-title">
+          <button class="modal-close" type="button" aria-label="Close" data-close>
+            &times;
+          </button>
+          <div class="modal-content">
+            <h2 class="modal-title" id="edit-title">Student Result Edit Overlay</h2>
+            <form class="edit-form" id="edit-form">
+              <div class="form-group">
+                <label for="edit-year">Year</label>
+                <input id="edit-year" name="year" type="text" />
+              </div>
+              <div class="form-group">
+                <label for="edit-term">Term</label>
+                <input id="edit-term" name="term" type="text" />
+              </div>
+              <div class="form-group">
+                <label for="edit-subject">Subject</label>
+                <input id="edit-subject" name="subject" type="text" />
+              </div>
+              <div class="form-group">
+                <label for="edit-exam">Exam</label>
+                <input id="edit-exam" name="exam" type="text" />
+              </div>
+              <div class="form-group">
+                <label for="edit-result">Result</label>
+                <input id="edit-result" name="result" type="text" />
+              </div>
+              <div class="form-group">
+                <label for="edit-grade">Grade</label>
+                <input id="edit-grade" name="grade" type="text" />
+              </div>
+
+              <div class="modal-actions">
+                <button type="submit" class="update-btn" id="update-btn">Update</button>
+                <button type="button" class="cancel-btn" data-close>Cancel</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+
+      <div class="modal" id="delete-modal" aria-hidden="true">
+        <div class="modal-backdrop" data-close></div>
+        <div class="modal-dialog modal-dialog-outline" aria-modal="true" aria-labelledby="delete-title">
+          <button class="modal-close" type="button" aria-label="Close" data-close>
+            &times;
+          </button>
+          <div class="modal-content">
+            <h2 class="modal-title delete-title" id="delete-title">Delete This Student’s Results?</h2>
+            <p class="modal-text">
+              Are you sure you want to delete this student’s selected results? This action is permanent and cannot be undone.
+            </p>
+            <div class="modal-actions modal-actions-split">
+              <button type="button" class="delete-btn-modal" id="confirm-delete">Yes, delete results</button>
+              <button type="button" class="cancel-btn" data-close>Cancel</button>
+            </div>
+          </div>
+        </div>
+      </div>
     </main>
     <footer id="footer"></footer>
     <script type="module" src="../app.js"></script>

--- a/pages/select-user.html
+++ b/pages/select-user.html
@@ -12,8 +12,11 @@
 <body>
     <header id="header"></header>
     <main>
-        <h1>Select User</h1>
-        <p>Search for the user below & select to make changes to their info:</p>
+        <h1 id="page-title">Select User</h1>
+        <div class="results-icon" hidden>
+            <img src="../public/icons/results.png" alt="Results" />
+        </div>
+        <p id="page-subtitle">Search for the user below & select to make changes to their info:</p>
         <div class="search-bar">
             <div class="search-wrapper">
                 <input type="text" id="search-input" placeholder="Search for user..." />
@@ -24,20 +27,21 @@
         </div>
 
         <div class="table-container">
-            <a href="#" class="add-user-btn">Add user</a>
+            <a href="#" class="add-user-btn" id="add-user-btn">Add user</a>
             <table>
                 <thead>
                     <tr>
-                        <th class="col-id">ID</th>
-                        <th class="col-hidden">First Name</th>
-                        <th class="th-last-name">
+                        <th class="col-id" id="id-header">ID</th>
+                        <th class="col-first-name col-hidden" id="first-name-header">First Name</th>
+                        <th class="th-last-name" id="last-name-header">
                             <span class="label-desktop">Last Name</span>
                             <span class="label-mobile">L. Name</span>
                         </th>
-                        <th class="col-hidden">Year</th>
-                        <th>Role</th>
-                        <th class="col-hidden">DOB</th>
-                        <th class="col-hidden"></th>
+                        <th class="col-year col-hidden" id="year-header">Year</th>
+                        <th class="col-role" id="role-header">Role</th>
+                        <th class="col-dob col-hidden" id="dob-header">DOB</th>
+                        <th class="col-actions col-hidden" id="action-header"></th>
+                        <th class="col-info"></th>
                     </tr>
                 </thead>
                 <tbody id="table-body"></tbody>
@@ -65,7 +69,7 @@
         </div>
 
         <div id="pagination" class="pagination"></div>
-        <a href="admin-dashboard.html" class="back-link">Back to dashboard</a>
+        <a href="admin-dashboard.html" class="back-link" id="back-link">Back to dashboard</a>
     </main>
     <footer id="footer"></footer>
     <script type="module" src="../app.js"></script>

--- a/pages/teacher-dashboard.html
+++ b/pages/teacher-dashboard.html
@@ -36,17 +36,12 @@
         <p>Add results</p>
       </button>
 
-      <a class="action-card" href="/pages/select-student.html">
+      <a class="action-card" href="select-user.html?mode=results&role=student">
         <img src="../public/icons/add-results.png" alt="View results" />
         <p>View results</p>
       </a>
 
       <div class="bottom-actions">
-        <button class="action-card">
-          <img src="../public/icons/user-circle.png" alt="See profile" />
-          <p>See profile</p>
-        </button>
-
         <button class="action-card logout-card">
           <img src="../public/icons/logout.png" alt="Log out" />
           <p>Log out</p>

--- a/src/my-results.js
+++ b/src/my-results.js
@@ -11,7 +11,41 @@ const filters = {
   search: "",
 };
 
+const urlParams = new URLSearchParams(window.location.search);
+const studentIdParam = urlParams.get("studentId") || urlParams.get("id");
+const isManageMode = Boolean(studentIdParam);
+
+let pendingRowId = null;
+
+function getStudentDisplayName(students, studentId) {
+  const student = students.find((user) => user.id === studentId);
+  if (!student) return null;
+  return `${student.firstName} ${student.lastName}`.trim();
+}
+
 document.addEventListener("DOMContentLoaded", () => {
+  document.body.classList.toggle("manage-results", isManageMode);
+
+  // Set back link URL based on mode
+  const backLink = document.getElementById("back-link");
+  if (backLink) {
+    if (isManageMode) {
+      backLink.href = "select-user.html?mode=results&role=student";
+      backLink.textContent = "Back to select student";
+    } else {
+      backLink.href = "student-dashboard.html";
+      backLink.textContent = "Back to dashboard";
+    }
+  }
+
+  if (studentIdParam) {
+    const titleEl = document.querySelector("main h1");
+    const subtitleEl = document.querySelector("main p");
+    if (titleEl) titleEl.textContent = "Student Results";
+    if (subtitleEl)
+      subtitleEl.textContent = "Here are the results for the selected student";
+  }
+
   const searchInput = document.getElementById("search-input");
   const searchButton = document.getElementById("search-button");
 
@@ -36,6 +70,21 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   document.getElementById("results-body").addEventListener("click", (e) => {
+    const actionBtn = e.target.closest("button[data-action]");
+    if (actionBtn) {
+      const action = actionBtn.dataset.action;
+      const rowId = actionBtn.dataset.rowId;
+
+      if (action === "edit") {
+        openEditModal(rowId);
+      }
+      if (action === "delete") {
+        openDeleteModal(rowId);
+      }
+
+      return;
+    }
+
     const yearCell = e.target.closest(".year-cell");
     if (yearCell) {
       filters.session = yearCell.dataset.session;
@@ -58,12 +107,23 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  fetch("../data/Results.json")
-    .then((response) => response.json())
-    .then((data) => {
-      const currentStudentId = "stu-101";
+  Promise.all([fetch("../data/Results.json"), fetch("../data/Students.json")])
+    .then(([resultsResponse, studentsResponse]) =>
+      Promise.all([resultsResponse.json(), studentsResponse.json()])
+    )
+    .then(([resultsData, studentsData]) => {
+      const currentStudentId = studentIdParam || "stu-101";
+      const students = studentsData.users || [];
+      const displayName = getStudentDisplayName(students, currentStudentId);
+      const subtitleEl = document.querySelector("main p");
 
-      const studentRecords = data.results.filter(
+      if (subtitleEl && displayName) {
+        subtitleEl.textContent = `Here are the results for ${displayName}`;
+      } else if (subtitleEl && studentIdParam) {
+        subtitleEl.textContent = `Here are the results for ${currentStudentId}`;
+      }
+
+      const studentRecords = resultsData.results.filter(
         (result) => result.studentId === currentStudentId
       );
 
@@ -85,13 +145,17 @@ document.addEventListener("DOMContentLoaded", () => {
         const termNumber = termMap[record.term] ?? record.term;
 
         record.subjects.forEach((subject) => {
+          const rowId = `${record.session}|${termNumber}|${subject.name}`;
           allRows.push({
+            id: rowId,
             year,
             session: record.session,
             term: termNumber,
             subject: subject.name,
             score: subject.score,
             grade: subject.grade,
+            exam: "E1",
+            outOf: 100,
           });
         });
       });
@@ -115,18 +179,24 @@ function renderPage(page) {
     const tr = document.createElement("tr");
 
     tr.innerHTML = `
-            <td class="col-year year-cell" data-session="${row.session}">${row.year}</td>
-            <td class="col-term term-cell" data-term="${row.term}">${row.term}</td>
-            <td class="col-subject subject-cell" data-subject="${row.subject}">${row.subject}</td>
-            <td>E1</td>
-            <td class="col-result">${row.score}/100</td>
-            <td>${row.grade}</td>
-            <td class="row-info">
-                <button class="info-btn">
-                    <img src="../public/icons/info.png" alt="Info">
-                </button>
-            </td>
-        `;
+        <td class="col-year year-cell" data-session="${row.session}">${row.year}</td>
+        <td class="col-term term-cell" data-term="${row.term}">${row.term}</td>
+        <td class="col-subject subject-cell" data-subject="${row.subject}">${row.subject}</td>
+        <td>${row.exam ?? "E1"}</td>
+        <td class="col-result">${row.score}/${row.outOf ?? 100}</td>
+        <td>${row.grade}</td>
+        <td class="col-actions col-hidden">
+          <div class="row-actions">
+          <button type="button" class="edit-link" data-action="edit" data-row-id="${row.id}">Edit</button>
+          <button type="button" class="delete-btn" data-action="delete" data-row-id="${row.id}">Delete</button>
+          </div>
+        </td>
+        <td class="row-info">
+          <button class="info-btn" type="button" data-action="edit" data-row-id="${row.id}">
+            <img src="../public/icons/info.png" alt="Info">
+          </button>
+        </td>
+      `;
 
     tbody.appendChild(tr);
   });
@@ -170,11 +240,27 @@ function renderPagination(totalItems) {
 
   pagination.innerHTML = "";
 
+  if (totalPages <= 1) return;
+
+  const addPageBtn = (page) => {
+    const btn = document.createElement("button");
+    btn.className = "page-btn";
+    if (page === currentPage) btn.classList.add("active");
+    btn.textContent = page;
+    btn.addEventListener("click", () => renderPage(page));
+    pagination.appendChild(btn);
+  };
+
+  const addEllipsis = () => {
+    const span = document.createElement("span");
+    span.className = "page-ellipsis";
+    span.textContent = "…";
+    pagination.appendChild(span);
+  };
+
   const firstBtn = createIconButton(
     "../public/icons/chevron-double-left.png",
-    () => {
-      renderPage(1);
-    }
+    () => renderPage(1)
   );
   firstBtn.disabled = currentPage === 1;
   pagination.appendChild(firstBtn);
@@ -185,19 +271,20 @@ function renderPagination(totalItems) {
   prevBtn.disabled = currentPage === 1;
   pagination.appendChild(prevBtn);
 
-  for (let page = 1; page <= totalPages; page++) {
-    const btn = document.createElement("button");
-    btn.className = "page-btn";
+  const pages = new Set([1, 2, totalPages - 1, totalPages]);
+  pages.add(currentPage);
+  pages.add(currentPage - 1);
+  pages.add(currentPage + 1);
 
-    if (page === currentPage) btn.classList.add("active");
+  const sortedPages = Array.from(pages)
+    .filter((p) => p >= 1 && p <= totalPages)
+    .sort((a, b) => a - b);
 
-    btn.textContent = page;
-
-    btn.addEventListener("click", () => {
-      renderPage(page);
-    });
-
-    pagination.appendChild(btn);
+  let lastRendered = 0;
+  for (const page of sortedPages) {
+    if (lastRendered && page - lastRendered > 1) addEllipsis();
+    addPageBtn(page);
+    lastRendered = page;
   }
 
   const nextBtn = createIconButton("../public/icons/chevron-right.png", () => {
@@ -208,9 +295,7 @@ function renderPagination(totalItems) {
 
   const lastBtn = createIconButton(
     "../public/icons/chevron-double-right.png",
-    () => {
-      renderPage(totalPages);
-    }
+    () => renderPage(totalPages)
   );
   lastBtn.disabled = currentPage === totalPages;
   pagination.appendChild(lastBtn);
@@ -219,6 +304,7 @@ function renderPagination(totalItems) {
 function createIconButton(iconPath, onClick) {
   const btn = document.createElement("button");
   btn.className = "page-btn";
+  btn.type = "button";
 
   const img = document.createElement("img");
   img.src = iconPath;
@@ -229,3 +315,117 @@ function createIconButton(iconPath, onClick) {
 
   return btn;
 }
+
+function openModal(modalEl) {
+  modalEl.setAttribute("aria-hidden", "false");
+  document.body.style.overflow = "hidden";
+}
+
+function closeModal(modalEl) {
+  modalEl.setAttribute("aria-hidden", "true");
+  document.body.style.overflow = "";
+}
+
+function getRowById(rowId) {
+  return allRows.find((row) => row.id === rowId) || null;
+}
+
+function openEditModal(rowId) {
+  const editModal = document.getElementById("edit-modal");
+  const row = getRowById(rowId);
+  if (!editModal || !row) return;
+
+  pendingRowId = rowId;
+
+  document.getElementById("edit-year").value = row.year ?? "";
+  document.getElementById("edit-term").value = row.term ?? "";
+  document.getElementById("edit-subject").value = row.subject ?? "";
+  document.getElementById("edit-exam").value = row.exam ?? "E1";
+  document.getElementById("edit-result").value = `${row.score}/${row.outOf ?? 100}`;
+  document.getElementById("edit-grade").value = row.grade ?? "";
+
+  // Make inputs read-only when not in manage mode
+  const inputs = editModal.querySelectorAll("input");
+  const updateBtn = document.getElementById("update-btn");
+  
+  if (!isManageMode) {
+    inputs.forEach(input => input.setAttribute("readonly", "readonly"));
+    if (updateBtn) updateBtn.style.display = "none";
+    editModal.querySelector(".modal-title").textContent = "Result Details";
+  } else {
+    inputs.forEach(input => input.removeAttribute("readonly"));
+    if (updateBtn) updateBtn.style.display = "";
+    editModal.querySelector(".modal-title").textContent = "Student Result Edit Overlay";
+  }
+
+  openModal(editModal);
+}
+
+function openDeleteModal(rowId) {
+  if (!isManageMode) return;
+  const deleteModal = document.getElementById("delete-modal");
+  if (!deleteModal) return;
+  pendingRowId = rowId;
+  openModal(deleteModal);
+}
+
+function wireModals() {
+  const editModal = document.getElementById("edit-modal");
+  const deleteModal = document.getElementById("delete-modal");
+  const editForm = document.getElementById("edit-form");
+  const confirmDelete = document.getElementById("confirm-delete");
+
+  const handleCloseClick = (e) => {
+    if (!e.target.closest("[data-close]")) return;
+    if (editModal && editModal.getAttribute("aria-hidden") === "false") closeModal(editModal);
+    if (deleteModal && deleteModal.getAttribute("aria-hidden") === "false") closeModal(deleteModal);
+    pendingRowId = null;
+  };
+
+  document.addEventListener("click", handleCloseClick);
+
+  if (editForm) {
+    editForm.addEventListener("submit", (e) => {
+      e.preventDefault();
+      if (!pendingRowId) return;
+
+      const row = getRowById(pendingRowId);
+      if (!row) return;
+
+      const yearVal = document.getElementById("edit-year").value.trim();
+      const termVal = document.getElementById("edit-term").value.trim();
+      const subjectVal = document.getElementById("edit-subject").value.trim();
+      const examVal = document.getElementById("edit-exam").value.trim();
+      const resultVal = document.getElementById("edit-result").value.trim();
+      const gradeVal = document.getElementById("edit-grade").value.trim();
+
+      const [scoreStr, outOfStr] = resultVal.split("/");
+      const parsedScore = Number(scoreStr);
+      const parsedOutOf = outOfStr ? Number(outOfStr) : row.outOf;
+
+      if (yearVal) row.year = yearVal;
+      if (termVal) row.term = Number(termVal) || termVal;
+      if (subjectVal) row.subject = subjectVal;
+      if (examVal) row.exam = examVal;
+      if (!Number.isNaN(parsedScore)) row.score = parsedScore;
+      if (parsedOutOf && !Number.isNaN(parsedOutOf)) row.outOf = parsedOutOf;
+      if (gradeVal) row.grade = gradeVal;
+
+      applyFilters();
+      if (editModal) closeModal(editModal);
+      pendingRowId = null;
+    });
+  }
+
+  if (confirmDelete) {
+    confirmDelete.addEventListener("click", () => {
+      if (!pendingRowId) return;
+      allRows = allRows.filter((row) => row.id !== pendingRowId);
+      pendingRowId = null;
+      applyFilters();
+      if (deleteModal) closeModal(deleteModal);
+    });
+  }
+}
+
+wireModals();

--- a/src/select-user.js
+++ b/src/select-user.js
@@ -3,6 +3,51 @@ let currentPage = 1;
 let users = [];
 let filteredUsers = [];
 
+const urlParams = new URLSearchParams(window.location.search);
+const viewMode = urlParams.get("mode");
+const roleFilter = urlParams.get("role");
+const isResultsMode = viewMode === "results";
+
+function applyModeUi() {
+  if (!isResultsMode) return;
+
+  document.body.classList.add("results-mode");
+
+  const titleEl = document.getElementById("page-title");
+  const subtitleEl = document.getElementById("page-subtitle");
+  const addUserBtn = document.getElementById("add-user-btn");
+  const actionHeader = document.getElementById("action-header");
+  const backLink = document.getElementById("back-link");
+  const resultsIcon = document.querySelector(".results-icon");
+  const firstNameHeader = document.getElementById("first-name-header");
+  const yearHeader = document.getElementById("year-header");
+  const roleHeader = document.getElementById("role-header");
+  const dobHeader = document.getElementById("dob-header");
+  const idHeader = document.getElementById("id-header");
+  const searchInput = document.getElementById("search-input");
+
+  if (titleEl) titleEl.textContent = "Select Student";
+  if (subtitleEl) subtitleEl.textContent = "Select student to view results";
+  if (addUserBtn) addUserBtn.style.display = "none";
+  if (actionHeader) actionHeader.classList.add("col-hidden");
+  if (resultsIcon) resultsIcon.removeAttribute("hidden");
+  if (searchInput) searchInput.placeholder = "Search for student...";
+  if (backLink) {
+    backLink.href = "teacher-dashboard.html";
+    backLink.textContent = "Back to dashboard";
+  }
+
+  // Update table headers for results mode
+  if (idHeader) idHeader.textContent = "Student ID";
+  if (firstNameHeader) firstNameHeader.classList.remove("col-hidden");
+  if (yearHeader) {
+    yearHeader.textContent = "Year";
+    yearHeader.classList.remove("col-hidden");
+  }
+  if (roleHeader) roleHeader.classList.add("col-hidden");
+  if (dobHeader) dobHeader.classList.add("col-hidden");
+}
+
 async function loadTableData() {
     try {
         const [studentsData, teachersData] = await Promise.all([
@@ -22,6 +67,10 @@ async function loadTableData() {
 
         users = [...students, ...teachers];
 
+        if (roleFilter) {
+          users = users.filter((user) => user.role === roleFilter);
+        }
+
         filteredUsers = users;
         renderPage(1);
     } catch (error) {
@@ -38,34 +87,55 @@ function renderPage(page) {
     const start = (page - 1) * rowsPerPage;
     const pageUsers = filteredUsers.slice(start, start + rowsPerPage);
 
-        tableBody.innerHTML = pageUsers.map (user => {
+        tableBody.innerHTML = pageUsers.map((user) => {
           const editUrl =
-              user.role === "student"
-              ? "./manage-student.html?id=" + user.id
-              : "./manage-teacher.html?id=" + user.id;
+            user.role === "student"
+            ? "./manage-student.html?id=" + user.id
+            : "./manage-teacher.html?id=" + user.id;
 
-              return`
-            <tr>
-                <td class="col-id">${user.id}</td>
-                <td class="col-hidden">${user.firstName}</td>
-                <td>${user.lastName}</td>
-                <td class="col-hidden">0000</td>
-                <td>${user.role}</td>
-                <td class="col-hidden">01/01/2000</td>
-                <td class="col-hidden col-actions">
-                    <div class="row-actions">
-                        <a href="${editUrl}" class="edit-link">Edit</a>
-                        <button 
-                            type="button" 
-                            class="delete-btn" 
-                            data-id="${user.id}">Delete</button>
-                    </div>
-                </td>
+          const resultsUrl = `./my-results.html?studentId=${user.id}`;
+
+          const actionCell = isResultsMode
+            ? ""
+            : `<div class="row-actions">
+                <a href="${editUrl}" class="edit-link">Edit</a>
+                <button 
+                  type="button" 
+                  class="delete-btn" 
+                  data-id="${user.id}">Delete</button>
+              </div>`;
+
+          const actionColClass = isResultsMode ? "col-hidden col-actions" : "col-hidden col-actions";
+
+          const infoCell = isResultsMode
+            ? `<td class="row-info">
+                <button class="info-btn" type="button" data-student-id="${user.id}">
+                  <img src="../public/icons/info.png" alt="View results">
+                </button>
+              </td>`
+            : `<td class="row-info"></td>`;
+
+          const rowClickAttr = isResultsMode ? `data-student-id="${user.id}" data-results-url="${resultsUrl}"` : "";
+
+          const firstNameClass = isResultsMode ? "col-first-name" : "col-first-name col-hidden";
+          const yearClass = isResultsMode ? "col-year" : "col-year col-hidden";
+          const roleClass = isResultsMode ? "col-role col-hidden" : "col-role";
+
+          return `
+            <tr ${rowClickAttr}>
+              <td class="col-id">${user.id}</td>
+              <td class="${firstNameClass}">${user.firstName}</td>
+              <td>${user.lastName}</td>
+              <td class="${yearClass}">2020</td>
+              <td class="${roleClass}">${user.role}</td>
+              <td class="col-dob col-hidden">01/01/2000</td>
+              <td class="${actionColClass}">
+                ${actionCell}
+              </td>
+              ${infoCell}
             </tr>
-        `;
-        }
-          
-          ).join("");
+          `;
+        }).join("");
 
     renderPagination(filteredUsers.length);    
 }
@@ -145,6 +215,7 @@ function renderPagination(totalItems) {
     return btn;
   };  
   
+applyModeUi();
 loadTableData();
 
 
@@ -206,6 +277,30 @@ function performSearch() {
 }
 
 searchButton.addEventListener("click", performSearch);
+
+// Handle row clicks and info button clicks in results mode
+if (isResultsMode) {
+  document.getElementById("table-body").addEventListener("click", (e) => {
+    // Handle info button click
+    const infoBtn = e.target.closest(".info-btn");
+    if (infoBtn) {
+      const studentId = infoBtn.dataset.studentId;
+      if (studentId) {
+        window.location.href = `./my-results.html?studentId=${studentId}`;
+      }
+      return;
+    }
+
+    // Handle row click (not on buttons)
+    const row = e.target.closest("tr[data-student-id]");
+    if (row && !e.target.closest("button")) {
+      const resultsUrl = row.dataset.resultsUrl;
+      if (resultsUrl) {
+        window.location.href = resultsUrl;
+      }
+    }
+  });
+}
 
 
 


### PR DESCRIPTION
Refactor styles and add management UX plus JS improvements across results and user selection pages. CSS updates (css/my-results.css, css/select-user.css) introduce consistent spacing variables, responsive tweaks, action columns, add-result/add-user buttons, modal/dialog styles, mobile visibility rules, and row info/action styling for manage/results modes. HTML changes (pages/my-results.html, pages/select-user.html, pages/admin-dashboard.html, pages/teacher-dashboard.html) wire up IDs, add action headers, add-result link, edit/delete modals, results icon, and update dashboard links to open the select-user page in results mode. JS (src/my-results.js) now detects manage/results mode from URL params, loads Students.json alongside Results.json, annotates rows with stable IDs, exposes edit/delete handlers via event delegation, improves pagination (ellipsis, icon buttons), and adds modal open/close and edit modal plumbing (with read-only logic when not in manage mode). Overall this enables selecting a student, viewing/managing their results, and improved mobile/desktop UX.

https://github.com/orgs/NoroffFEU/projects/414?pane=issue&itemId=142411845&issue=NoroffFEU%7Cedu-gate-aug24-pt%7C45